### PR TITLE
TetrAMM: read final ACK when NAQ != 0

### DIFF
--- a/quadEMApp/src/drvTetrAMM.cpp
+++ b/quadEMApp/src/drvTetrAMM.cpp
@@ -262,6 +262,18 @@ void drvTetrAMM::readThread(void)
                         (triggerMode == QETriggerModeInternal) &&
                         (numAcquired_ >= numAverage)) {
                         acquiring_ = 0;
+                        status = pasynOctet->read(octetPvt, pasynUser, charData,
+                                                  sizeof("ACK\r\n")-1, &nRead, &eomReason);
+
+                        if (status == asynSuccess) {
+                            asynPrint(pasynUserSelf, ASYN_TRACEIO_DRIVER,
+                                "%s:%s: found ACK at the end of packet (with NAQ != 0)\n",
+                                driverName, functionName);
+                        } else {
+                            asynPrint(pasynUserSelf, ASYN_TRACE_ERROR,
+                                "%s:%s: error: ACK not found at end of packet(status=%d, nRead=%lu, eomReason=%d)\n",
+                                driverName, functionName, status, (unsigned long)nRead, eomReason);
+                        }
                     }
                     if ((acquireMode == QEAcquireModeContinuous) &&
                         (triggerMode == QETriggerModeExtTrigger)) {


### PR DESCRIPTION
When NAQ is different than 0, TetrAMM first transmits out NAQ samples and at the
end appends ACK\r\n to indicate that the acquisition has finished. The IOC now
reads 5 bytes after the NAQ samples have been captured to flush out the ACK\r\n
from buffer.
