### PR TITLE
Update paths to simplify multiply device deployment

### DIFF
--- a/iocBoot/AHxxx.cmd
+++ b/iocBoot/AHxxx.cmd
@@ -15,7 +15,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX), R=asyn1,PORT=IP_$(PORT),
 drvAHxxxConfigure("$(PORT)", "IP_$(PORT)", $(RING_SIZE), $(MODEL))
 dbLoadRecords("$(QUADEM)/db/$(TEMPLATE).template", "P=$(PREFIX), R=$(RECORD):, PORT=$(PORT)")
 
-< ../commonPlugins.cmd
+< $(QUADEM)/iocBoot/commonPlugins.cmd
 
 asynSetTraceIOMask("$(PORT)",0,2)
 #asynSetTraceMask("$(PORT)",  0,9)

--- a/iocBoot/iocAH501/AH501.cmd
+++ b/iocBoot/iocAH501/AH501.cmd
@@ -8,10 +8,10 @@ epicsEnvSet("RING_SIZE", "10000")
 epicsEnvSet("TSPOINTS",  "1000")
 epicsEnvSet("IP",        "164.54.160.11:10001")
 
-< ../AHxxx.cmd
+< $(QUADEM)/iocBoot/AHxxx.cmd
 dbLoadRecords("$(QUADEM)/db/AH501.template", "P=$(PREFIX), R=$(RECORD):, PORT=$(PORT)")
 
-< ../saveRestore.cmd
+< $(QUADEM)/iocBoot/saveRestore.cmd
 
 iocInit()
 

--- a/iocBoot/iocAH501/st.cmd
+++ b/iocBoot/iocAH501/st.cmd
@@ -3,11 +3,11 @@ errlogInit(5000)
 
 # Tell EPICS all about the record types, device-support modules, drivers,
 # etc. in this build
-dbLoadDatabase("../../dbd/quadEMTestApp.dbd")
+dbLoadDatabase("$(QUADEM)/dbd/quadEMTestApp.dbd")
 quadEMTestApp_registerRecordDeviceDriver(pdbbase)
 
 # The search path for database files
 # Note: the separator between the path entries needs to be changed to a semicolon (;) on Windows
 epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(QUADEM)/db")
 
-< AH501.cmd
+< $(QUADEM)/iocBoot/iocAH501/AH501.cmd

--- a/iocBoot/iocNSLS_EM/NSLS_EM.cmd
+++ b/iocBoot/iocNSLS_EM/NSLS_EM.cmd
@@ -22,7 +22,7 @@ asynSetTraceIOMask("TCP_Data_$(PORT)", 0, 2)
 
 dbLoadRecords("$(QUADEM)/db/$(TEMPLATE).template", "P=$(PREFIX), R=$(RECORD):, PORT=$(PORT)")
 
-< ../commonPlugins.cmd
+< $(QUADEM)/iocBoot/commonPlugins.cmd
 
 asynSetTraceIOMask("$(PORT)",0,2)
 #asynSetTraceMask("$(PORT)",  0,9)
@@ -37,7 +37,7 @@ asynSetTraceIOMask("$(PORT)",0,2)
 initFastSweep("$(PORT)TS", "$(PORT)", 11, 2048, "QE_INT_ARRAY_DATA", "QE_SAMPLE_TIME")
 dbLoadRecords("$(QUADEM)/db/quadEM_TimeSeries.template", "P=$(PREFIX),R=$(RECORD)_TS:,NUM_TS=2048,NUM_FREQ=1024,PORT=$(PORT)TS")
 
-< ../saveRestore.cmd
+< $(QUADEM)/iocBoot/saveRestore.cmd
 
 iocInit()
 

--- a/iocBoot/iocNSLS_EM/st.cmd
+++ b/iocBoot/iocNSLS_EM/st.cmd
@@ -3,11 +3,11 @@ errlogInit(5000)
 
 # Tell EPICS all about the record types, device-support modules, drivers,
 # etc. in this build
-dbLoadDatabase("../../dbd/quadEMTestApp.dbd")
+dbLoadDatabase("$(QUADEM)/dbd/quadEMTestApp.dbd")
 quadEMTestApp_registerRecordDeviceDriver(pdbbase)
 
 # The search path for database files
 # Note: the separator between the path entries needs to be changed to a semicolon (;) on Windows
 epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(QUADEM)/db")
 
-< NSLS_EM.cmd
+< $(QUADEM)/iocBoot/iocNSLS_EM/NSLS_EM.cmd

--- a/iocBoot/iocTetrAMM/TetrAMM.cmd
+++ b/iocBoot/iocTetrAMM/TetrAMM.cmd
@@ -25,7 +25,7 @@ dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX), R=asyn1,PORT=IP_$(PORT),
 drvTetrAMMConfigure("$(PORT)", "IP_$(PORT)", $(RING_SIZE))
 dbLoadRecords("$(QUADEM)/db/$(TEMPLATE).template", "P=$(PREFIX), R=$(RECORD):, PORT=$(PORT)")
 
-< ../commonPlugins.cmd
+< $(QUADEM)/iocBoot/commonPlugins.cmd
 
 asynSetTraceIOMask("$(PORT)",0,2)
 #asynSetTraceMask("$(PORT)",  0,9)
@@ -40,7 +40,7 @@ asynSetTraceIOMask("$(PORT)",0,2)
 initFastSweep("$(PORT)TS", "$(PORT)", 11, 2048, "QE_INT_ARRAY_DATA", "QE_SAMPLE_TIME")
 dbLoadRecords("$(QUADEM)/db/quadEM_TimeSeries.template", "P=$(PREFIX),R=$(RECORD)_TS:,NUM_TS=2048,NUM_FREQ=1024,PORT=$(PORT)TS")
 
-< ../saveRestore.cmd
+< $(QUADEM)/iocBoot/saveRestore.cmd
 
 iocInit()
 

--- a/iocBoot/iocTetrAMM/st.cmd
+++ b/iocBoot/iocTetrAMM/st.cmd
@@ -3,11 +3,11 @@ errlogInit(5000)
 
 # Tell EPICS all about the record types, device-support modules, drivers,
 # etc. in this build
-dbLoadDatabase("../../dbd/quadEMTestApp.dbd")
+dbLoadDatabase("$(QUADEM)/dbd/quadEMTestApp.dbd")
 quadEMTestApp_registerRecordDeviceDriver(pdbbase)
 
 # The search path for database files
 # Note: the separator between the path entries needs to be changed to a semicolon (;) on Windows
 epicsEnvSet("EPICS_DB_INCLUDE_PATH", "$(ADCORE)/db:$(QUADEM)/db")
 
-< TetrAMM.cmd
+< $(QUADEM)/iocBoot/iocTetrAMM/TetrAMM.cmd


### PR DESCRIPTION
Mark,
Using $(QUADEM) macro simplifies deployment when many devices are used on the same beamline. Please consider the pull.

Kaz
