### PR TITLE
Place conditional around sequencer lib

### DIFF
--- a/quadEMApp/src/Makefile
+++ b/quadEMApp/src/Makefile
@@ -48,7 +48,12 @@ PROD_SRCS_vxWorks += $(PROD_NAME)Vx_registerRecordDeviceDriver.cpp
 PROD_LIBS += quadEM
 PROD_LIBS_vxWorks += Ipac
 PROD_LIBS_vxWorks += ipUnidig
-PROD_LIBS += seq pv
+
+
+ifdef SNCSEQ
+	PROD_LIBS += seq
+	PROD_LIBS += pv
+endif
 
 # Need to put this in or there are missing symbols on vxWorks because Ipac and IpUnidig are linked
 # in after PROD_LIBS, which has EPICS_BASE_IOC_LIBS from commonDriverMakefile


### PR DESCRIPTION
If building without the sequencer, which I believe is optional for CALC, quadEM still tries to link against `libpv` and `libseq` even if `SNQSEC` is unset in `configure/RELEASE`

This change makes that optional. 