### PR TITLE
Add tetramm interlock status and clear register fault on setBiasState

### DIFF
--- a/quadEMApp/Db/TetrAMM.template
+++ b/quadEMApp/Db/TetrAMM.template
@@ -41,3 +41,22 @@ record(mbbi,"$(P)$(R)TriggerMode_RBV") {
     field(THVL, "4")
     field(THST, "Ext. gate")
 }
+
+record(bi,"$(P)$(R)InterlockStatus_RBV") {
+    field(DESC, "Interlock status")
+    field(DTYP, "asynInt32")
+    field(ZNAM, "OK")
+    field(ONAM, "Interlocked")
+    field(INP,  "@asyn($(PORT) 0) TETRAMM_INTERLOCK_STATUS")
+    field(SCAN, "I/O Intr")
+}
+
+record(calcout,"$(P)$(R)InterlockCheck"){
+    field(DESC, "Disable HV if Interlock trips")
+    field(INPA, "$(P)$(R)InterlockStatus_RBV CP")
+    field(CALC, "A")
+    field(OUT,  "$(P)$(R)BiasState PP")
+    field(OCAL, "0")
+    field(OOPT, "Transition To Non-zero")
+    field(DOPT, "Use OCAL")   
+}

--- a/quadEMApp/Db/TetrAMM.template
+++ b/quadEMApp/Db/TetrAMM.template
@@ -45,8 +45,8 @@ record(mbbi,"$(P)$(R)TriggerMode_RBV") {
 record(bi,"$(P)$(R)InterlockStatus_RBV") {
     field(DESC, "Interlock status")
     field(DTYP, "asynInt32")
-    field(ZNAM, "OK")
-    field(ONAM, "Interlocked")
+    field(ZNAM, "HV Enabled")
+    field(ONAM, "HV Disabled")
     field(INP,  "@asyn($(PORT) 0) TETRAMM_INTERLOCK_STATUS")
     field(SCAN, "I/O Intr")
 }

--- a/quadEMApp/op/adl/TetrAMM.adl
+++ b/quadEMApp/op/adl/TetrAMM.adl
@@ -1,14 +1,14 @@
 
 file {
-	name="/home/epics/devel/quadEM-9-1/quadEMApp/op/adl/TetrAMM.adl"
-	version=030109
+	name="/home/omitto/Workspaces/epics/quadEM/quadEMApp/op/adl/TetrAMM.adl"
+	version=030111
 }
 display {
 	object {
-		x=785
-		y=334
+		x=775
+		y=326
 		width=430
-		height=275
+		height=302
 	}
 	clr=14
 	bclr=4
@@ -251,8 +251,8 @@ text {
 }
 text {
 	object {
-		x=30
-		y=225
+		x=31
+		y=249
 		width=160
 		height=20
 	}
@@ -264,8 +264,8 @@ text {
 }
 "text update" {
 	object {
-		x=195
-		y=225
+		x=196
+		y=249
 		width=100
 		height=20
 	}
@@ -279,8 +279,8 @@ text {
 }
 text {
 	object {
-		x=80
-		y=250
+		x=81
+		y=274
 		width=110
 		height=20
 	}
@@ -292,8 +292,8 @@ text {
 }
 "text update" {
 	object {
-		x=195
-		y=250
+		x=196
+		y=274
 		width=100
 		height=20
 	}
@@ -307,8 +307,8 @@ text {
 }
 text {
 	object {
-		x=30
-		y=200
+		x=31
+		y=224
 		width=160
 		height=20
 	}
@@ -320,8 +320,8 @@ text {
 }
 "text update" {
 	object {
-		x=195
-		y=200
+		x=196
+		y=224
 		width=100
 		height=20
 	}
@@ -335,8 +335,8 @@ text {
 }
 text {
 	object {
-		x=60
-		y=175
+		x=61
+		y=199
 		width=130
 		height=20
 	}
@@ -348,8 +348,8 @@ text {
 }
 "text update" {
 	object {
-		x=195
-		y=175
+		x=196
+		y=199
 		width=100
 		height=20
 	}
@@ -489,5 +489,33 @@ menu {
 		chan="$(P)$(R)TriggerPolarity"
 		clr=14
 		bclr=51
+	}
+}
+text {
+	object {
+		x=60
+		y=175
+		width=130
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Interlock readback"
+	align="horiz. right"
+}
+"text update" {
+	object {
+		x=196
+		y=175
+		width=100
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)InterlockStatus_RBV"
+		clr=54
+		bclr=3
+	}
+	limits {
 	}
 }

--- a/quadEMApp/src/drvTetrAMM.h
+++ b/quadEMApp/src/drvTetrAMM.h
@@ -11,6 +11,7 @@
 #include "drvQuadEM.h"
 
 #define MAX_COMMAND_LEN 256
+#define P_InterlockStatusString  "TETRAMM_INTERLOCK_STATUS"             /* asynInt32,    r/w */
 
 /** Class to control the CaenEls TetrAMM 4-Channel Picoammeter */
 class drvTetrAMM : public drvQuadEM {
@@ -41,6 +42,7 @@ protected:
     virtual asynStatus setTriggerMode(epicsInt32 value);
     virtual asynStatus setTriggerPolarity(epicsInt32 value);
     virtual asynStatus setValuesPerRead(epicsInt32 value);
+    int P_InterlockStatus;
  
 private:
     /* Our data */


### PR DESCRIPTION
Hi,
I was trying to use the external Interlock option with a tetramm device and realized that before the HV can be re-enabled, a STATUS:RESET needs to be sent (https://www.caenels.com/wp-content/uploads/2015/04/TetrAMM_UsersManual_V1.5.pdf - page 39-41). This PR sends a STATUS:RESET on setBiasState and update the General Fault Bit to InterlockStatus_RBV.