### PR TITLE
Add NSLS2_IC to Model

### DIFF
--- a/quadEMApp/Db/quadEM.template
+++ b/quadEMApp/Db/quadEM.template
@@ -30,6 +30,8 @@ record(mbbi,"$(P)$(R)Model") {
     field(NIST, "NSLS_EM")
     field(TEVL, "10")
     field(TEST, "NSLS2_EM")
+    field(ELVL, "11")
+    field(ELST, "NSLS2_IC")
     field(SCAN, "I/O Intr")
 }
 


### PR DESCRIPTION
NSLS2_IC is already part of QEModel_t enum but missing from the Model record.