### PR TITLE
Add a software driver to get data into quadEM IOC

### DIFF
--- a/quadEMApp/Db/SoftQuadEM.template
+++ b/quadEMApp/Db/SoftQuadEM.template
@@ -1,0 +1,21 @@
+# Database for software electrometer
+include "quadEM.template"
+
+record(waveform, "$(P)$(R)DataIn")
+{
+    field (DESC, "Data Input")
+    field (DTYP, "asynFloat64ArrayOut")
+    field (INP,  "@asyn($(PORT))QES_DATA_IN")
+    field (NELM, "4")
+    field (FTVL, "DOUBLE")
+}
+
+record(ao, "$(P)$(R)SampleTime")
+{
+    field (DESC, "Sampling time (sec)")
+    field (PINI, "YES")
+    field (PREC, "4")
+    field (VAL,  "0.1")
+    field (DTYP, "asynFloat64")
+    field (OUT,  "@asyn($(PORT) 0)QE_SAMPLE_TIME")
+}

--- a/quadEMApp/Db/quadEM.template
+++ b/quadEMApp/Db/quadEM.template
@@ -32,6 +32,8 @@ record(mbbi,"$(P)$(R)Model") {
     field(TEST, "NSLS2_EM")
     field(ELVL, "11")
     field(ELST, "NSLS2_IC")
+    field(TVVL, "12")
+    field(TVST, "SoftDevice")
     field(SCAN, "I/O Intr")
 }
 

--- a/quadEMApp/src/Makefile
+++ b/quadEMApp/src/Makefile
@@ -16,6 +16,7 @@ DBD += drvTetrAMM.dbd
 DBD += drvNSLS_EM.dbd
 DBD += drvNSLS2_EM.dbd
 #DBD += drvNSLS2_IC.dbd
+DBD += drvSoftQuadEM.dbd
 DBD += quadEMTestApp.dbd
 DBD += quadEMTestAppVx.dbd
 
@@ -28,6 +29,7 @@ quadEM_SRCS         += drvTetrAMM.cpp
 quadEM_SRCS         += drvNSLS_EM.cpp
 quadEM_SRCS         += drvNSLS2_EM.cpp
 #quadEM_SRCS         += drvNSLS2_IC.cpp
+quadEM_SRCS         += drvSoftQuadEM.cpp
 quadEM_SRCS_vxWorks += drvAPS_EM.cpp
 
 quadEM_LIBS_vxWorks += Ipac

--- a/quadEMApp/src/drvQuadEM.cpp
+++ b/quadEMApp/src/drvQuadEM.cpp
@@ -51,8 +51,8 @@ drvQuadEM::drvQuadEM(const char *portName, int ringBufferSize)
    : asynNDArrayDriver(portName, 
                     QE_MAX_DATA+1, /* maxAddr */ 
                     0, 0,        /* maxBuffers, maxMemory, no limits */
-                    asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynGenericPointerMask | asynDrvUserMask, /* Interface mask */
-                    asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynGenericPointerMask,                   /* Interrupt mask */
+                    asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynFloat64ArrayMask | asynGenericPointerMask | asynDrvUserMask, /* Interface mask */
+                    asynInt32Mask | asynInt32ArrayMask | asynFloat64Mask | asynFloat64ArrayMask | asynGenericPointerMask,                   /* Interrupt mask */
                     ASYN_CANBLOCK | ASYN_MULTIDEVICE, /* asynFlags.  This driver blocks it is multi-device */
                     1, /* Autoconnect */
                     0, /* Default priority */

--- a/quadEMApp/src/drvQuadEM.h
+++ b/quadEMApp/src/drvQuadEM.h
@@ -66,7 +66,8 @@ typedef enum {
     QE_ModelTetrAMM,
     QE_ModelNSLS_EM,
     QE_ModelNSLS2_EM,
-    QE_ModelNSLS2_IC
+    QE_ModelNSLS2_IC,
+    QE_ModelSoftDevice
 } QEModel_t;
 
 /* These enums give the offsets into the data array for each value */

--- a/quadEMApp/src/drvSoftQuadEM.cpp
+++ b/quadEMApp/src/drvSoftQuadEM.cpp
@@ -42,6 +42,8 @@ drvSoftQuadEM::drvSoftQuadEM(const char *portName, int ringBufferSize)
     : drvQuadEM(portName, ringBufferSize), acquire_(0)
 {
     createParam(QES_DataInString,     asynParamFloat64Array,  &QES_DataIn);
+
+    setIntegerParam(P_Model, QE_ModelSoftDevice);
 }
 
 drvSoftQuadEM::~drvSoftQuadEM()

--- a/quadEMApp/src/drvSoftQuadEM.cpp
+++ b/quadEMApp/src/drvSoftQuadEM.cpp
@@ -1,0 +1,147 @@
+/*  drvSoftQuadEM.cpp
+    A driver to get electronmeter readouts from a 4-element EPICS array (waveform record).
+*/
+
+#include <math.h>
+
+#include <epicsThread.h>
+#include <epicsTime.h>
+#include <errlog.h>
+#include <iocsh.h>
+
+#include <drvQuadEM.h>
+
+#include <epicsExport.h>
+
+static const char *driverName = "drvSoftQuadEM";
+
+#define QES_DataInString  "QES_DATA_IN"
+
+class drvSoftQuadEM : public drvQuadEM
+{
+public:
+    drvSoftQuadEM(const char *portName, int ringBufferSize);
+    ~drvSoftQuadEM();
+
+    asynStatus writeFloat64Array(asynUser *pasynUser, epicsFloat64 *value, size_t nElements);
+
+protected:
+    virtual asynStatus setAveragingTime(epicsFloat64 value);
+    virtual asynStatus setAcquire(epicsInt32 value);
+    virtual asynStatus readStatus();
+    virtual asynStatus reset();
+
+private:
+    int QES_DataIn;
+    #define FIRST_QES_COMMAND QES_DataIn
+
+    int acquire_;
+};
+
+drvSoftQuadEM::drvSoftQuadEM(const char *portName, int ringBufferSize)
+    : drvQuadEM(portName, ringBufferSize), acquire_(0)
+{
+    createParam(QES_DataInString,     asynParamFloat64Array,  &QES_DataIn);
+}
+
+drvSoftQuadEM::~drvSoftQuadEM()
+{
+}
+
+asynStatus drvSoftQuadEM::setAcquire(epicsInt32 value)
+{
+    acquire_ = value;
+    return asynSuccess;
+}
+
+asynStatus drvSoftQuadEM::readStatus()
+{
+    return asynSuccess;
+}
+
+asynStatus drvSoftQuadEM::reset()
+{
+    asynStatus status;
+
+    status = drvQuadEM::reset();
+    return status;
+}
+
+asynStatus drvSoftQuadEM::setAveragingTime(epicsFloat64 value)
+{
+    int numAverage;
+    double sampleTime;
+    double averagingTime;
+
+    getDoubleParam (P_SampleTime, &sampleTime);
+    getDoubleParam (P_AveragingTime, &averagingTime);
+
+    numAverage = (int)((averagingTime / sampleTime) + 0.5);
+    setIntegerParam(P_NumAverage, numAverage);
+
+    return asynSuccess;
+}
+
+asynStatus drvSoftQuadEM::writeFloat64Array(asynUser *pasynUser, epicsFloat64 *value, size_t nElements)
+{
+    int function = pasynUser->reason;
+    int status = asynSuccess;
+    const char *paramName;
+    const char* functionName = "writeFloat64Array";
+
+    /* Fetch the parameter string name for possible use in debugging */
+    getParamName(function, &paramName);
+
+    if (function == QES_DataIn) {
+        if (nElements == 4) {
+            if (acquire_)
+                computePositions(value);
+        }
+        else {
+            status = asynError;
+        }
+    }
+    else if (function < FIRST_QES_COMMAND) {
+        status = drvQuadEM::writeFloat64Array(pasynUser, value, nElements);
+    }
+
+    if (status)
+        epicsSnprintf(pasynUser->errorMessage, pasynUser->errorMessageSize, 
+                  "%s:%s: status=%d, function=%d, name=%s", 
+                  driverName, functionName, status, function, paramName);
+    else        
+        asynPrint(pasynUser, ASYN_TRACEIO_DRIVER, 
+              "%s:%s: function=%d, name=%s\n", 
+              driverName, functionName, function, paramName);
+
+    return (asynStatus)status;
+}
+
+extern "C" {
+
+int drvSoftQuadEMConfigure(const char *portName, int ringBufferSize)
+{
+    new drvSoftQuadEM(portName, ringBufferSize);
+    return(asynSuccess);
+}
+
+
+/* EPICS iocsh shell commands */
+
+static const iocshArg initArg0 = { "portName", iocshArgString};
+static const iocshArg initArg1 = { "ring buffer size",iocshArgInt};
+static const iocshArg * const initArgs[] = {&initArg0, &initArg1};
+static const iocshFuncDef initFuncDef = {"drvSoftQuadEMConfigure", 2, initArgs};
+static void initCallFunc(const iocshArgBuf *args)
+{
+    drvSoftQuadEMConfigure(args[0].sval, args[2].ival);
+}
+
+void drvSoftQuadEMRegister(void)
+{
+    iocshRegister(&initFuncDef, initCallFunc);
+}
+
+epicsExportRegistrar(drvSoftQuadEMRegister);
+
+}

--- a/quadEMApp/src/drvSoftQuadEM.dbd
+++ b/quadEMApp/src/drvSoftQuadEM.dbd
@@ -1,0 +1,1 @@
+registrar(drvSoftQuadEMRegister)


### PR DESCRIPTION
It allows user to feed data into the quadEM IOC, much like NDDriverStdArrays for areaDetector IOC.

In my case the current is first amplified and converted to 0-10V by a [LoCum-4](https://www.esrf.fr/computing/cs/tango/tango_doc/ds_doc/tango-ds/Instrumentation/LoCuM_4/user_guide.pdf), and then read out by analog input modules on an EhterCAT bus. Using this driver I would maintain the same interface as other systems using AH501 and TetrAMM. 