### PR TITLE
Fix std module URL in quadEMDoc.html

### DIFF
--- a/docs/quadEMDoc.html
+++ b/docs/quadEMDoc.html
@@ -118,7 +118,7 @@
       <p>
         This can provide "fast feedback" via an asyn D/A converter (e.g. dac128V), also
         at speeds up to 20000 Hz, 6510 Hz, 1000Hz, 2500 Hz, or 813Hz. If it is run slower
-        it does signal averaging. This support is provided in the synApps <a href="http://www.aps.anl.gov/bcda/synApps/std/std.html">
+        it does signal averaging. This support is provided in the synApps <a href="https://epics-modules.github.io/std/">
           std</a> module. The quadEM drivers do the callbacks on the asynFloat64 interface
         required to use the epid fast feedback device support. This fast feedback is limited
         to controlling devices in the same IOC as the quadEM driver, because it uses asyn


### PR DESCRIPTION
Fix the broken URL for the std module link.