### PR TITLE
Add packages to quadEMApp Makefile. Add HDF5 plugin to common plugins.

### DIFF
--- a/iocBoot/commonPlugins.cmd
+++ b/iocBoot/commonPlugins.cmd
@@ -70,6 +70,10 @@ dbLoadRecords("$(ADCORE)/db/NDTimeSeries.template",  "P=$(PREFIX),R=$(RECORD)$(T
 NDFileNetCDFConfigure("$(PORT)_FileNetCDF1", $(QSIZE), 0, "$(PORT)", 11)
 dbLoadRecords("$(ADCORE)/db/NDFileNetCDF.template","P=$(PREFIX),R=$(RECORD)netCDF1:,PORT=$(PORT)_FileNetCDF1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT),NDARRAY_ADDR=11,ENABLED=0")
 
+# Create an HDF5 file saving plugin
+NDFileHDF5Configure("$(PORT)_FileHDF1", $(QSIZE), 0, "$(PORT)", 11)
+dbLoadRecords("$(ADCORE)/db/NDFileHDF5.template",  "P=$(PREFIX),R=$(RECORD)HDF1:,PORT=$(PORT)_FileHDF1,ADDR=0,TIMEOUT=1,XMLSIZE=2048,NDARRAY_PORT=$(PORT),NDARRAY_ADDR=11,ENABLED=0")
+
 # This creates a waveform large enough for 11x10000 arrays.
 NDStdArraysConfigure("$(PORT)_Image1", $(QSIZE), 0, "$(PORT)", 11)
 dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=$(RECORD)image1:,PORT=$(PORT)_Image1,ADDR=0,TIMEOUT=1,NDARRAY_PORT=$(PORT),NDARRAY_ADDR=11,TYPE=Float64,FTVL=DOUBLE,NELEMENTS=110000,ENABLED=0")

--- a/quadEMApp/Db/quadEM_Plugin_settings.req
+++ b/quadEMApp/Db/quadEM_Plugin_settings.req
@@ -10,6 +10,7 @@ file "NDStats_settings.req",           P=$(P), R=$(R)DiffY:
 file "NDStats_settings.req",           P=$(P), R=$(R)PosX:
 file "NDStats_settings.req",           P=$(P), R=$(R)PosY:
 file "NDFileNetCDF_settings.req",      P=$(P), R=$(R)netCDF1:
+file "NDFileHDF5_settings.req",        P=$(P), R=$(R)HDF1:
 file "NDStdArrays_settings.req",       P=$(P), R=$(R)image1:
 file "NDTimeSeries_settings.req",      P=$(P), R=$(R)TS:
 file "NDTimeSeriesN_settings.req",     P=$(P), R=$(R)TS:Current1:

--- a/quadEMApp/src/Makefile
+++ b/quadEMApp/src/Makefile
@@ -60,12 +60,20 @@ ifdef SNCSEQ
     PROD_LIBS += pv
 endif
 
+PROD_LIBS += busy
+PROD_LIBS += calc
+
+PROD_LIBS += autosave
+PROD_LIBS += devIocStats
+PROD_LIBS += reccaster
+
 # Need to put this in or there are missing symbols on vxWorks because Ipac and IpUnidig are linked
 # in after PROD_LIBS, which has EPICS_BASE_IOC_LIBS from commonDriverMakefile
 PROD_LIBS_vxWorks += $(EPICS_BASE_IOC_LIBS)
 
 include $(ADCORE)/ADApp/commonLibraryMakefile
 include $(ADCORE)/ADApp/commonDriverMakefile
+
 $(PROD_NAME)_DBD += drvAsynIPPort.dbd
 $(PROD_NAME)_DBD += drvAHxxx.dbd
 $(PROD_NAME)_DBD += drvTetrAMM.dbd
@@ -73,10 +81,26 @@ $(PROD_NAME)_DBD += drvNSLS_EM.dbd
 $(PROD_NAME)_DBD += drvNSLS2_EM.dbd
 #$(PROD_NAME)_DBD += drvNSLS2_IC.dbd
 $(PROD_NAME)_DBD += drvPCR4.dbd
-$(PROD_NAME)_DBD += drvPCR4.dbd
-$(PROD_NAME)_DBD += drvPCR4.dbd
 $(PROD_NAME)_DBD += drvT4U_EM.dbd
 $(PROD_NAME)_DBD += drvT4UDirect_EM.dbd
+
+$(PROD_NAME)_DBD += NDFileNetCDF.dbd
+$(PROD_NAME)_DBD += NDFileHDF5.dbd
+
+$(PROD_NAME)_DBD += busySupport.dbd
+$(PROD_NAME)_DBD += calcSupport.dbd
+$(PROD_NAME)_DBD += devIocStats.dbd
+$(PROD_NAME)_DBD += asSupport.dbd
+$(PROD_NAME)_DBD += reccaster.dbd
+
+
+# Link QSRV (pvAccess Server) if available
+ifdef EPICS_QSRV_MAJOR_VERSION
+    PROD_LIBS += qsrv
+    PROD_LIBS += $(EPICS_BASE_PVA_CORE_LIBS)
+    $(PROD_NAME)_DBD += PVAServerRegister.dbd
+    $(PROD_NAME)_DBD += qsrv.dbd
+endif
 
 PROD_NAME = quadEMTestApp
 


### PR DESCRIPTION
Changes in the current PR:

- The following modules are added to Makefile for the `quadEMApp`: `busy`, `calc` (both are required to run the app with TetrAMM), `autosave`, `devIocStats`, `reccaster`.

- `quadEMApp` is now built with `qsrv` if supported.

- HDF5 plugin was added to the list of common plugins. Also `NDFileNetCDF.dbd` and `NDFileHDF5.dbd` were added to the Makefile for the `quadEMApp`.