### PR TITLE
Support for custom geometries, as used for APS XBPMs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,11 @@
 The versions of EPICS base, asyn, ADCore, and other synApps modules used for each release can be obtained from 
 the configure/RELEASE file in each release of quadEM.
 
+## Release 9-7 (unreleased)
+- Added a Custom geometry that allows user-defined weights for computing the sum
+  and difference values from the four current inputs, along with custom X/Y axis labels.
+  Thanks to John Runchey from ANL for this.
+
 ## Release 9-6 (November 29, 2025)
 - Added a software driver to get data into the quadEM. It is similar to the NDDriverStdArrays for areaDetector.
   Thanks to Xiaoqiang Wang from PSI for this.

--- a/docs/source/databases.rst
+++ b/docs/source/databases.rst
@@ -237,7 +237,9 @@ minimum, maximum, and other statistics, including a histogram of array values.
 
       - 0: Diamond
       - 1: Square
- 
+      - 2: SquareCC
+      - 3: Custom
+
   * - QE_RESOLUTION
     - $(P)$(R)Resolution, $(P)$(R)Resolution_RBV
     - mbbo, mbbi
@@ -614,6 +616,41 @@ minimum, maximum, and other statistics, including a histogram of array values.
       are typically between 1e-4 to 1e-12. It is convenient to use a CurrentScale of 1e9
       or 1e12, for example, so that the data are displayed in units of nano-amps or pico-amps.
       They are then reasonable sized integers, and the time series software can be used.
+  * - QE_WEIGHT_XSUM
+    - $(P)$(R)WeightXsum[1-4]
+    - ao
+    - asynFloat64 (addr=0-3)
+    - r/w
+    - All
+    - Weights applied to each current input when computing SumX in Custom geometry.
+  * - QE_WEIGHT_YSUM
+    - $(P)$(R)WeightYsum[1-4]
+    - ao
+    - asynFloat64 (addr=0-3)
+    - r/w
+    - All
+    - Weights applied to each current input when computing SumY in Custom geometry.
+  * - QE_WEIGHT_XDELTA
+    - $(P)$(R)WeightXdelta[1-4]
+    - ao
+    - asynFloat64 (addr=0-3)
+    - r/w
+    - All
+    - Weights applied to each current input when computing DiffX in Custom geometry.
+  * - QE_WEIGHT_YDELTA
+    - $(P)$(R)WeightYdelta[1-4]
+    - ao
+    - asynFloat64 (addr=0-3)
+    - r/w
+    - All
+    - Weights applied to each current input when computing DiffY in Custom geometry.
+  * - N.A.
+    - $(P)$(R)Xlabel, $(P)$(R)Ylabel
+    - stringin
+    - N.A.
+    - r/w
+    - All
+    - Custom labels for the X and Y axes, used with the Custom geometry.
   * - N.A.
     - $(P)$(R)CurrentPrec[1-4]
     - mbbo

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -192,6 +192,11 @@ R9-5 added a variant of the square geometry, SquareCC::
 
 - It is similar to Square, but the 4 diodes are arranged counterclockwise.
   SumX=SumY=(1+2+3+4), DiffX=(3+4)-(1+2), DiffY=(1+4)-(2+3).
-  
+
+A Custom geometry is also available for non-standard detector arrangements. In this mode
+the user provides a set of four weights for each of the computed values (SumX, SumY, DiffX,
+DiffY). Each output is computed as the weighted sum of the four input currents. Custom axis
+labels can also be set via the Xlabel and Ylabel PVs.
+
 For all geometries SumAll=(1+2+3+4), PositionX=DiffX/SumX, and PositionY=DiffY/SumY.
-X positive is to the right and Y positive is up for both geometries.
+X positive is to the right and Y positive is up for the standard geometries.

--- a/quadEMApp/Db/quadEM.template
+++ b/quadEMApp/Db/quadEM.template
@@ -475,6 +475,8 @@ record(mbbo,"$(P)$(R)Geometry") {
     field(ONST, "Square")
     field(TWVL, "2")
     field(TWST, "SquareCC")
+    field(THVL, "3")
+    field(THST, "Custom")
     field(DTYP, "asynInt32")
     field(OUT,  "@asyn($(PORT) 0)QE_GEOMETRY")
 }
@@ -487,9 +489,23 @@ record(mbbi,"$(P)$(R)Geometry_RBV") {
     field(ONST, "Square")
     field(TWVL, "2")
     field(TWST, "SquareCC")
+    field(THVL, "3")
+    field(THST, "Custom")
     field(DTYP, "asynInt32")
     field(INP,  "@asyn($(PORT) 0)QE_GEOMETRY")
     field(SCAN, "I/O Intr")
+}
+
+record(stringin,"$(P)$(R)Xlabel") {
+    field(PINI, "YES")
+    field(DESC, "X label")
+    field(VAL,  "X")
+}
+
+record(stringin,"$(P)$(R)Ylabel") {
+    field(PINI, "YES")
+    field(DESC, "Y label")
+    field(VAL,  "Y")
 }
 
 record(stringin,"$(P)$(R)CurrentName1") {
@@ -768,6 +784,152 @@ record(ao,"$(P)$(R)CurrentScale4") {
     field(PREC, "3")
 }
 
+record(ao,"$(P)$(R)WeightXsum1") {
+    field(DESC, "Wxsum 1")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 0)QE_WEIGHT_XSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXsum2") {
+    field(DESC, "Wxsum 2")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 1)QE_WEIGHT_XSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXsum3") {
+    field(DESC, "Wxsum 3")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 2)QE_WEIGHT_XSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXsum4") {
+    field(DESC, "Wxsum 4")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 3)QE_WEIGHT_XSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYsum1") {
+    field(DESC, "Wysum 1")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 0)QE_WEIGHT_YSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYsum2") {
+    field(DESC, "Wysum 2")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 1)QE_WEIGHT_YSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYsum3") {
+    field(DESC, "Wysum 3")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 2)QE_WEIGHT_YSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYsum4") {
+    field(DESC, "Wysum 4")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 3)QE_WEIGHT_YSUM")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXdelta1") {
+    field(DESC, "Wxdelta 1")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 0)QE_WEIGHT_XDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXdelta2") {
+    field(DESC, "Wxdelta 2")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 1)QE_WEIGHT_XDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXdelta3") {
+    field(DESC, "Wxdelta 3")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 2)QE_WEIGHT_XDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightXdelta4") {
+    field(DESC, "Wxdelta 4")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 3)QE_WEIGHT_XDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYdelta1") {
+    field(DESC, "Wydelta 1")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 0)QE_WEIGHT_YDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYdelta2") {
+    field(DESC, "Wydelta 2")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 1)QE_WEIGHT_YDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYdelta3") {
+    field(DESC, "Wydelta 3")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 2)QE_WEIGHT_YDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
+
+record(ao,"$(P)$(R)WeightYdelta4") {
+    field(DESC, "Wydelta 4")
+    field(PINI, "YES")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT) 3)QE_WEIGHT_YDELTA")
+    field(VAL,  "1.0")
+    field(PREC, "3")
+}
 record(mbbo,"$(P)$(R)PositionPrecX") {
     field(DESC, "Precision")
     field(OUT, "$(P)$(R)PositionPrecFanoutX PP")

--- a/quadEMApp/op/adl/customWeights.adl
+++ b/quadEMApp/op/adl/customWeights.adl
@@ -1,0 +1,1555 @@
+
+file {
+	name="/home/phoebus3/JRUNCHEY/C2/devel/quadEM-R9-4/quadEMApp/op/adl/customWeights.adl"
+	version=030116
+}
+display {
+	object {
+		x=433
+		y=366
+		width=502
+		height=350
+	}
+	clr=14
+	bclr=3
+	cmap=""
+	gridSpacing=5
+	gridOn=0
+	snapToGrid=0
+}
+"color map" {
+	ncolors=65
+	colors {
+		ffffff,
+		ececec,
+		dadada,
+		c8c8c8,
+		bbbbbb,
+		aeaeae,
+		9e9e9e,
+		919191,
+		858585,
+		787878,
+		696969,
+		5a5a5a,
+		464646,
+		2d2d2d,
+		000000,
+		00d800,
+		1ebb00,
+		339900,
+		2d7f00,
+		216c00,
+		fd0000,
+		de1309,
+		be190b,
+		a01207,
+		820400,
+		5893ff,
+		597ee1,
+		4b6ec7,
+		3a5eab,
+		27548d,
+		fbf34a,
+		f9da3c,
+		eeb62b,
+		e19015,
+		cd6100,
+		ffb0ff,
+		d67fe2,
+		ae4ebc,
+		8b1a96,
+		610a75,
+		a4aaff,
+		8793e2,
+		6a73c1,
+		4d52a4,
+		343386,
+		c7bb6d,
+		b79d5c,
+		a47e3c,
+		7d5627,
+		58340f,
+		99ffff,
+		73dfff,
+		4ea5f9,
+		2a63e4,
+		0a00b8,
+		ebf1b5,
+		d4db9d,
+		bbc187,
+		a6a462,
+		8b8239,
+		73ff6b,
+		52da3b,
+		3cb420,
+		289315,
+		1a7309,
+	}
+}
+text {
+	object {
+		x=14
+		y=121
+		width=60
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="XSum ="
+}
+text {
+	object {
+		x=14
+		y=260
+		width=60
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="YSum ="
+}
+"text entry" {
+	object {
+		x=98
+		y=76
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXsum1"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=98
+		y=103
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXsum2"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=98
+		y=130
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXsum3"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=98
+		y=157
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXsum4"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+polyline {
+	object {
+		x=82
+		y=65
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(83,66)
+		(83,183)
+	}
+}
+polyline {
+	object {
+		x=81
+		y=65
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(82,67)
+		(103,66)
+	}
+}
+polyline {
+	object {
+		x=81
+		y=180
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(82,182)
+		(103,181)
+	}
+}
+polyline {
+	object {
+		x=158
+		y=180
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(159,182)
+		(180,181)
+	}
+}
+polyline {
+	object {
+		x=158
+		y=65
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(159,67)
+		(180,66)
+	}
+}
+polyline {
+	object {
+		x=179
+		y=65
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(180,66)
+		(180,183)
+	}
+}
+text {
+	object {
+		x=205
+		y=76
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=216
+		y=86
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="1"
+}
+text {
+	object {
+		x=205
+		y=103
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=216
+		y=113
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="2"
+}
+text {
+	object {
+		x=205
+		y=130
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=216
+		y=140
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="3"
+}
+text {
+	object {
+		x=205
+		y=157
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=216
+		y=167
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="4"
+}
+polyline {
+	object {
+		x=191
+		y=181
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(192,183)
+		(205,182)
+	}
+}
+polyline {
+	object {
+		x=192
+		y=66
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(193,67)
+		(193,184)
+	}
+}
+polyline {
+	object {
+		x=191
+		y=66
+		width=14
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(192,68)
+		(204,67)
+	}
+}
+polyline {
+	object {
+		x=217
+		y=66
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(218,68)
+		(231,67)
+	}
+}
+polyline {
+	object {
+		x=231
+		y=66
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(232,67)
+		(232,184)
+	}
+}
+polyline {
+	object {
+		x=217
+		y=181
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(218,183)
+		(231,182)
+	}
+}
+text {
+	object {
+		x=249
+		y=260
+		width=60
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="YDelta ="
+}
+text {
+	object {
+		x=249
+		y=121
+		width=60
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="XDelta ="
+}
+"text entry" {
+	object {
+		x=353
+		y=81
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXdelta1"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=353
+		y=108
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXdelta2"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=353
+		y=135
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXdelta3"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=353
+		y=162
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightXdelta4"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+polyline {
+	object {
+		x=337
+		y=70
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(338,71)
+		(338,188)
+	}
+}
+polyline {
+	object {
+		x=336
+		y=70
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(337,72)
+		(358,71)
+	}
+}
+polyline {
+	object {
+		x=336
+		y=185
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(337,187)
+		(358,186)
+	}
+}
+polyline {
+	object {
+		x=413
+		y=185
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(414,187)
+		(435,186)
+	}
+}
+polyline {
+	object {
+		x=413
+		y=70
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(414,72)
+		(435,71)
+	}
+}
+polyline {
+	object {
+		x=434
+		y=70
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(435,71)
+		(435,188)
+	}
+}
+text {
+	object {
+		x=460
+		y=81
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=471
+		y=91
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="1"
+}
+text {
+	object {
+		x=460
+		y=108
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=471
+		y=118
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="2"
+}
+text {
+	object {
+		x=460
+		y=135
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=471
+		y=145
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="3"
+}
+text {
+	object {
+		x=460
+		y=162
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=471
+		y=172
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="4"
+}
+polyline {
+	object {
+		x=446
+		y=186
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(447,188)
+		(460,187)
+	}
+}
+polyline {
+	object {
+		x=447
+		y=71
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(448,72)
+		(448,189)
+	}
+}
+polyline {
+	object {
+		x=446
+		y=71
+		width=14
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(447,73)
+		(459,72)
+	}
+}
+polyline {
+	object {
+		x=472
+		y=71
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(473,73)
+		(486,72)
+	}
+}
+polyline {
+	object {
+		x=486
+		y=71
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(487,72)
+		(487,189)
+	}
+}
+polyline {
+	object {
+		x=472
+		y=186
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(473,188)
+		(486,187)
+	}
+}
+"text entry" {
+	object {
+		x=97
+		y=216
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYsum1"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=97
+		y=243
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYsum2"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=97
+		y=270
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYsum3"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=97
+		y=297
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYsum4"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+polyline {
+	object {
+		x=81
+		y=205
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(82,206)
+		(82,323)
+	}
+}
+polyline {
+	object {
+		x=80
+		y=205
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(81,207)
+		(102,206)
+	}
+}
+polyline {
+	object {
+		x=80
+		y=320
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(81,322)
+		(102,321)
+	}
+}
+polyline {
+	object {
+		x=157
+		y=320
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(158,322)
+		(179,321)
+	}
+}
+polyline {
+	object {
+		x=157
+		y=205
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(158,207)
+		(179,206)
+	}
+}
+polyline {
+	object {
+		x=178
+		y=205
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(179,206)
+		(179,323)
+	}
+}
+text {
+	object {
+		x=204
+		y=216
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=215
+		y=226
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="1"
+}
+text {
+	object {
+		x=204
+		y=243
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=215
+		y=253
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="2"
+}
+text {
+	object {
+		x=204
+		y=270
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=215
+		y=280
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="3"
+}
+text {
+	object {
+		x=204
+		y=297
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=215
+		y=307
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="4"
+}
+polyline {
+	object {
+		x=190
+		y=321
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(191,323)
+		(204,322)
+	}
+}
+polyline {
+	object {
+		x=191
+		y=206
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(192,207)
+		(192,324)
+	}
+}
+polyline {
+	object {
+		x=190
+		y=206
+		width=14
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(191,208)
+		(203,207)
+	}
+}
+polyline {
+	object {
+		x=216
+		y=206
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(217,208)
+		(230,207)
+	}
+}
+polyline {
+	object {
+		x=230
+		y=206
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(231,207)
+		(231,324)
+	}
+}
+polyline {
+	object {
+		x=216
+		y=321
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(217,323)
+		(230,322)
+	}
+}
+"text entry" {
+	object {
+		x=352
+		y=223
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYdelta1"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=352
+		y=250
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYdelta2"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=352
+		y=277
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYdelta3"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+"text entry" {
+	object {
+		x=352
+		y=304
+		width=70
+		height=17
+	}
+	control {
+		chan="$(P)$(R)WeightYdelta4"
+		clr=14
+		bclr=51
+	}
+	limits {
+	}
+}
+polyline {
+	object {
+		x=336
+		y=212
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(337,213)
+		(337,330)
+	}
+}
+polyline {
+	object {
+		x=335
+		y=212
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(336,214)
+		(357,213)
+	}
+}
+polyline {
+	object {
+		x=335
+		y=327
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(336,329)
+		(357,328)
+	}
+}
+polyline {
+	object {
+		x=412
+		y=327
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(413,329)
+		(434,328)
+	}
+}
+polyline {
+	object {
+		x=412
+		y=212
+		width=23
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(413,214)
+		(434,213)
+	}
+}
+polyline {
+	object {
+		x=433
+		y=212
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(434,213)
+		(434,330)
+	}
+}
+text {
+	object {
+		x=459
+		y=223
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=470
+		y=233
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="1"
+}
+text {
+	object {
+		x=459
+		y=250
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=470
+		y=260
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="2"
+}
+text {
+	object {
+		x=459
+		y=277
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=470
+		y=287
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="3"
+}
+text {
+	object {
+		x=459
+		y=304
+		width=20
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="I"
+}
+text {
+	object {
+		x=470
+		y=314
+		width=10
+		height=10
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="4"
+}
+polyline {
+	object {
+		x=445
+		y=328
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(446,330)
+		(459,329)
+	}
+}
+polyline {
+	object {
+		x=446
+		y=213
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(447,214)
+		(447,331)
+	}
+}
+polyline {
+	object {
+		x=445
+		y=213
+		width=14
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(446,215)
+		(458,214)
+	}
+}
+polyline {
+	object {
+		x=471
+		y=213
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(472,215)
+		(485,214)
+	}
+}
+polyline {
+	object {
+		x=485
+		y=213
+		width=2
+		height=119
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(486,214)
+		(486,331)
+	}
+}
+polyline {
+	object {
+		x=471
+		y=328
+		width=15
+		height=3
+	}
+	"basic attribute" {
+		clr=14
+		width=2
+	}
+	points {
+		(472,330)
+		(485,329)
+	}
+}
+text {
+	object {
+		x=221
+		y=9
+		width=100
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="($(P)$(R))"
+	align="horiz. centered"
+}
+text {
+	object {
+		x=106
+		y=37
+		width=330
+		height=20
+	}
+	"basic attribute" {
+		clr=14
+	}
+	textix="Weights for Custom geometry only!"
+	align="horiz. centered"
+}

--- a/quadEMApp/op/adl/quadEM.adl
+++ b/quadEMApp/op/adl/quadEM.adl
@@ -87,6 +87,22 @@ display {
 		1a7309,
 	}
 }
+"related display" {
+	object {
+		x=24
+		y=184
+		width=90
+		height=22
+	}
+	display[0] {
+		name="customWeights.adl"
+		args="P=$(P),R=$(R)"
+	}
+	clr=14
+	bclr=35
+	label="Weights"
+	visual="a row of buttons"
+}
 rectangle {
 	object {
 		x=0
@@ -783,32 +799,6 @@ text {
 	}
 	textix="Scale"
 	align="horiz. right"
-}
-text {
-	object {
-		x=702
-		y=287
-		width=10
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="Y"
-	align="horiz. centered"
-}
-text {
-	object {
-		x=601
-		y=287
-		width=10
-		height=20
-	}
-	"basic attribute" {
-		clr=14
-	}
-	textix="X"
-	align="horiz. centered"
 }
 text {
 	object {
@@ -2492,8 +2482,8 @@ composite {
 	object {
 		x=10
 		y=460
-		width=390
-		height=45
+		width=392
+		height=294
 	}
 	"composite name"=""
 	"composite file"="NSLS_EM.adl"
@@ -2703,4 +2693,38 @@ composite {
 	}
 	"composite name"=""
 	"composite file"="ADBuffers.adl"
+}
+"text update" {
+	object {
+		x=552
+		y=287
+		width=100
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)Xlabel"
+		clr=14
+		bclr=3
+	}
+	align="horiz. centered"
+	format="string"
+	limits {
+	}
+}
+"text update" {
+	object {
+		x=658
+		y=287
+		width=100
+		height=20
+	}
+	monitor {
+		chan="$(P)$(R)Ylabel"
+		clr=14
+		bclr=3
+	}
+	align="horiz. centered"
+	format="string"
+	limits {
+	}
 }

--- a/quadEMApp/src/drvQuadEM.cpp
+++ b/quadEMApp/src/drvQuadEM.cpp
@@ -64,6 +64,10 @@ drvQuadEM::drvQuadEM(const char *portName, int ringBufferSize)
     asynUser *pasynUser;
     
     createParam(P_AcquireModeString,        asynParamInt32,         &P_AcquireMode);
+    createParam(P_WeightXsumString,         asynParamFloat64,       &P_WeightXsum);
+    createParam(P_WeightYsumString,         asynParamFloat64,       &P_WeightYsum);
+    createParam(P_WeightXdeltaString,       asynParamFloat64,       &P_WeightXdelta);
+    createParam(P_WeightYdeltaString,       asynParamFloat64,       &P_WeightYdelta);
     createParam(P_CurrentOffsetString,      asynParamFloat64,       &P_CurrentOffset);
     createParam(P_CurrentScaleString,       asynParamFloat64,       &P_CurrentScale);
     createParam(P_PositionOffsetString,     asynParamFloat64,       &P_PositionOffset);
@@ -211,11 +215,41 @@ void drvQuadEM::computePositions(epicsFloat64 raw[QE_MAX_INPUTS])
         doubleData[QEDiffY]  = (doubleData[QECurrent1] + doubleData[QECurrent4]) -
                                (doubleData[QECurrent2] + doubleData[QECurrent3]);
     }
-    else {
+    else if (geometry == QEGeometryDiamond) {
         doubleData[QESumX]   = doubleData[QECurrent1] + doubleData[QECurrent2];
         doubleData[QESumY]   = doubleData[QECurrent3] + doubleData[QECurrent4];
         doubleData[QEDiffX]  = doubleData[QECurrent2] - doubleData[QECurrent1];
         doubleData[QEDiffY]  = doubleData[QECurrent4] - doubleData[QECurrent3];
+    }
+    else if (geometry == QEGeometryCustom) {
+        epicsFloat64 weightXsum[QE_MAX_INPUTS];
+        epicsFloat64 weightYsum[QE_MAX_INPUTS];
+        epicsFloat64 weightXdelta[QE_MAX_INPUTS];
+        epicsFloat64 weightYdelta[QE_MAX_INPUTS];
+        
+        for (i=0; i<QE_MAX_INPUTS; i++) {
+            getDoubleParam(i, P_WeightXsum, &weightXsum[i]);
+            getDoubleParam(i, P_WeightYsum, &weightYsum[i]);
+            getDoubleParam(i, P_WeightXdelta, &weightXdelta[i]);
+            getDoubleParam(i, P_WeightYdelta, &weightYdelta[i]);
+        }
+        
+        doubleData[QESumX]  = weightXsum[0] * doubleData[QECurrent1] +
+                              weightXsum[1] * doubleData[QECurrent2] +
+                              weightXsum[2] * doubleData[QECurrent3] +
+                              weightXsum[3] * doubleData[QECurrent4];
+        doubleData[QESumY]  = weightYsum[0] * doubleData[QECurrent1] +
+                              weightYsum[1] * doubleData[QECurrent2] +
+                              weightYsum[2] * doubleData[QECurrent3] +
+                              weightYsum[3] * doubleData[QECurrent4];
+        doubleData[QEDiffX] = weightXdelta[0] * doubleData[QECurrent1] +
+                              weightXdelta[1] * doubleData[QECurrent2] +
+                              weightXdelta[2] * doubleData[QECurrent3] +
+                              weightXdelta[3] * doubleData[QECurrent4];
+        doubleData[QEDiffY] = weightYdelta[0] * doubleData[QECurrent1] +
+                              weightYdelta[1] * doubleData[QECurrent2] +
+                              weightYdelta[2] * doubleData[QECurrent3] +
+                              weightYdelta[3] * doubleData[QECurrent4];
     }
     denom = doubleData[QESumX];
     if (denom == 0.) denom = 1.;

--- a/quadEMApp/src/drvQuadEM.h
+++ b/quadEMApp/src/drvQuadEM.h
@@ -18,6 +18,10 @@
 #define P_AcquireModeString        "QE_ACQUIRE_MODE"            /* asynInt32,    r/w */
 #define P_CurrentOffsetString      "QE_CURRENT_OFFSET"          /* asynFloat64,  r/w */
 #define P_CurrentScaleString       "QE_CURRENT_SCALE"           /* asynFloat64,  r/w */
+#define P_WeightXsumString         "QE_WEIGHT_XSUM"             /* asynFloat64,  r/w */
+#define P_WeightYsumString         "QE_WEIGHT_YSUM"             /* asynFloat64,  r/w */
+#define P_WeightXdeltaString       "QE_WEIGHT_XDELTA"           /* asynFloat64,  r/w */
+#define P_WeightYdeltaString       "QE_WEIGHT_YDELTA"           /* asynFloat64,  r/w */
 #define P_PositionOffsetString     "QE_POSITION_OFFSET"         /* asynFloat64,  r/w */
 #define P_PositionScaleString      "QE_POSITION_SCALE"          /* asynFloat64,  r/w */
 #define P_GeometryString           "QE_GEOMETRY"                /* asynInt32,    r/w */
@@ -89,7 +93,8 @@ typedef enum {
 typedef enum {
     QEGeometryDiamond,
     QEGeometrySquare,
-    QEGeometrySquareCC
+    QEGeometrySquareCC,
+    QEGeometryCustom
 } QEGeometry_t;
 
 /* Acquire modes */
@@ -142,6 +147,10 @@ protected:
     /** Values used for pasynUser->reason, and indexes into the parameter library. */
     int P_AcquireMode;
     #define FIRST_QE_COMMAND P_AcquireMode
+    int P_WeightXsum;
+    int P_WeightYsum;
+    int P_WeightXdelta;
+    int P_WeightYdelta;
     int P_CurrentOffset;
     int P_CurrentScale;
     int P_PositionOffset;


### PR DESCRIPTION
John Runchey worked in the APS Controls group during the APS Upgrade development and added the code here that supports custom geometries. His changes to the R9-4 release have been used for the Xray BPMs (xbpm) IOCs, and he submitted a PR #20 at the time to try to upstream them, but it was never merged. After he left he apparently cleaned up his GitHub account and deleted his fork, which automatically closed the PR.

The first commit in this PR includes his original code, rebased against the latest R9-6 release of quadEM.
The second commit was documentation developed by Claude Code that describes the changes. I have no objection to any changes needed to fix its wording.

I have compiled this, but not tested it. We are currently upgrading the xbpm IOCs to use R9-6 with this addition though, so any breakage should be discovered very soon.